### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##BeYourMarket [![Try online](https://img.shields.io/badge/try-demo-green.svg)](http://demo.beyourmarket.com) [![Documentation Status](https://img.shields.io/badge/documentation-1v-blue.svg)](https://beyourmarket.atlassian.net) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/beyourmarket/beyourmarket/blob/master/LICENSE) [![Github Issues](http://issuestats.com/github/beyourmarket/beyourmarket/badge/issue)](https://github.com/beyourmarket/beyourmarket/issues)
+## BeYourMarket [![Try online](https://img.shields.io/badge/try-demo-green.svg)](http://demo.beyourmarket.com) [![Documentation Status](https://img.shields.io/badge/documentation-1v-blue.svg)](https://beyourmarket.atlassian.net) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/beyourmarket/beyourmarket/blob/master/LICENSE) [![Github Issues](http://issuestats.com/github/beyourmarket/beyourmarket/badge/issue)](https://github.com/beyourmarket/beyourmarket/issues)
 
 BeYourMarket is a free open source marketplace framework built on the ASP.NET platform.
 http://beyourmarket.com
@@ -25,7 +25,7 @@ Development Branch (`dev`)
 
 [Beauty and spa service Quick Start](http://www.codeproject.com/Articles/1001019/BeYourMarket-An-net-open-source-marketplace-framew)
 
-##Demo
+## Demo
 [![Try online](https://img.shields.io/badge/try-demo-green.svg)](http://demo.beyourmarket.com)
 
 Frontend:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
